### PR TITLE
fix pyproject.toml for uv build and dependency management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,13 @@
+[build-system]
+requires = ["uv-build>=0.2"]
+build-backend = "uv_build.backend"
+
 [project]
 name = "my-app"
 version = "0.1.0"
 description = "FastAPI project"
 readme = "README.md"
-required-version = ">=3.12"
+requires-python = ">=3.12"
 dependencies = [
     "fastapi",
     "uvicorn[standard]",
@@ -15,7 +19,4 @@ dependencies = [
     "pydantic-settings",
     "alembic>=1.16.4",
 ]
-
-[tool.uv]
-python = "3.12"
 

--- a/uv.lock
+++ b/uv.lock
@@ -273,7 +273,7 @@ wheels = [
 [[package]]
 name = "my-app"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },


### PR DESCRIPTION
 Added [build-system] section with uv-build backend
 Removed unnecessary [tool.uv] section for a cleaner config.